### PR TITLE
feat: implement player-ghost collision detection and game over scene (Task 7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,11 @@ require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/go-text/typesetting v0.2.0 // indirect
 	github.com/hajimehoshi/ebiten/v2 v2.8.8 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
+	golang.org/x/image v0.20.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/text v0.18.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,17 @@ github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj
 github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
 github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/go-text/typesetting v0.2.0 h1:fbzsgbmk04KiWtE+c3ZD4W2nmCRzBqrqQOvYlwAOdho=
+github.com/go-text/typesetting v0.2.0/go.mod h1:2+owI/sxa73XA581LAzVuEBZ3WEEV2pXeDswCH/3i1I=
 github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
 github.com/hajimehoshi/ebiten/v2 v2.8.8/go.mod h1:durJ05+OYnio9b8q0sEtOgaNeBEQG7Yr7lRviAciYbs=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+golang.org/x/image v0.20.0 h1:7cVCUjQwfL18gyBJOmYvptfSHS8Fb3YUDtfLIZ7Nbpw=
+golang.org/x/image v0.20.0/go.mod h1:0a88To4CYVBAHp5FXJm8o7QbUl37Vd85ply1vyD8auM=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
 golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
+golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/main.go
+++ b/main.go
@@ -202,6 +202,11 @@ func (gs *GameScene) Update() Scene {
 	gs.player.Update(gs.maze)
 	gs.ghost.Update(gs.maze)
 	gs.checkItemCollection()
+	
+	if gs.checkPlayerGhostCollision() {
+		return &GameOverScene{}
+	}
+	
 	return gs
 }
 
@@ -218,6 +223,17 @@ func (gs *GameScene) checkItemCollection() {
 			gs.Score += 50
 		}
 	}
+}
+
+func (gs *GameScene) checkPlayerGhostCollision() bool {
+	playerRadius := float64(TileSize) / 3
+	ghostRadius := float64(TileSize) / 3
+	
+	dx := gs.player.X - gs.ghost.X
+	dy := gs.player.Y - gs.ghost.Y
+	distance := dx*dx + dy*dy
+	
+	return distance < (playerRadius+ghostRadius)*(playerRadius+ghostRadius)
 }
 
 func (gs *GameScene) Draw(screen *ebiten.Image) {
@@ -249,6 +265,102 @@ func (gos *GameOverScene) Update() Scene {
 }
 
 func (gos *GameOverScene) Draw(screen *ebiten.Image) {
+	screen.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 255})
+	
+	screenWidth := 32 * TileSize
+	screenHeight := 17 * TileSize
+	
+	centerX := float32(screenWidth / 2)
+	centerY := float32(screenHeight / 2)
+	
+	vector.DrawFilledRect(screen, centerX-150, centerY-40, 300, 80, color.RGBA{R: 255, G: 255, B: 255, A: 255}, false)
+	vector.DrawFilledRect(screen, centerX-145, centerY-35, 290, 70, color.RGBA{R: 255, G: 0, B: 0, A: 255}, false)
+	
+	vector.DrawFilledRect(screen, centerX-130, centerY-20, 260, 40, color.RGBA{R: 0, G: 0, B: 0, A: 255}, false)
+	
+	letters := [][]bool{
+		// G
+		{true, true, true, true, true},
+		{true, false, false, false, false},
+		{true, false, true, true, true},
+		{true, false, false, false, true},
+		{true, true, true, true, true},
+		
+		// A
+		{false, true, true, true, false},
+		{true, false, false, false, true},
+		{true, true, true, true, true},
+		{true, false, false, false, true},
+		{true, false, false, false, true},
+		
+		// M
+		{true, false, false, false, true},
+		{true, true, false, true, true},
+		{true, false, true, false, true},
+		{true, false, false, false, true},
+		{true, false, false, false, true},
+		
+		// E
+		{true, true, true, true, true},
+		{true, false, false, false, false},
+		{true, true, true, true, false},
+		{true, false, false, false, false},
+		{true, true, true, true, true},
+		
+		// (space)
+		{false, false, false, false, false},
+		{false, false, false, false, false},
+		{false, false, false, false, false},
+		{false, false, false, false, false},
+		{false, false, false, false, false},
+		
+		// O
+		{false, true, true, true, false},
+		{true, false, false, false, true},
+		{true, false, false, false, true},
+		{true, false, false, false, true},
+		{false, true, true, true, false},
+		
+		// V
+		{true, false, false, false, true},
+		{true, false, false, false, true},
+		{false, true, false, true, false},
+		{false, true, false, true, false},
+		{false, false, true, false, false},
+		
+		// E
+		{true, true, true, true, true},
+		{true, false, false, false, false},
+		{true, true, true, true, false},
+		{true, false, false, false, false},
+		{true, true, true, true, true},
+		
+		// R
+		{true, true, true, true, false},
+		{true, false, false, false, true},
+		{true, true, true, true, false},
+		{true, false, false, true, false},
+		{true, false, false, false, true},
+	}
+	
+	pixelSize := float32(3)
+	letterSpacing := float32(20)
+	startX := centerX - float32(9*int(letterSpacing))/2
+	
+	for letterIndex := 0; letterIndex < 9; letterIndex++ {
+		letterStartX := startX + float32(letterIndex)*letterSpacing
+		
+		for row := 0; row < 5; row++ {
+			for col := 0; col < 5; col++ {
+				letterArrayIndex := letterIndex * 5 + row
+				if letterArrayIndex < len(letters) && col < len(letters[letterArrayIndex]) && letters[letterArrayIndex][col] {
+					x := letterStartX + float32(col)*pixelSize
+					y := centerY - 10 + float32(row)*pixelSize
+					vector.DrawFilledRect(screen, x, y, pixelSize, pixelSize, color.RGBA{R: 255, G: 255, B: 255, A: 255}, false)
+				}
+			}
+		}
+	}
 }
 
 type Game struct {


### PR DESCRIPTION
## Summary
- プレイヤーとゴーストの衝突判定を距離計算で実装
- 衝突時にGameOverSceneに遷移する処理を追加
- ドット絵風の「GAME OVER」テキスト表示をvectorパッケージで実装
- ゲームオーバーメッセージの背景とボーダーを追加

## Test plan
- [x] ゲームが正常に起動する
- [x] プレイヤーがゴーストに触れるとゲームオーバー画面に遷移
- [x] 「GAME OVER」テキストが画面中央に表示される
- [x] 既存の機能（移動、アイテム収集、ゴーストAI）が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)